### PR TITLE
feat: real-time WebSocket sync for machines and notifications

### DIFF
--- a/app/src/main/java/com/example/mylavanderiapp/core/network/LaundryApi.kt
+++ b/app/src/main/java/com/example/mylavanderiapp/core/network/LaundryApi.kt
@@ -59,7 +59,6 @@ interface LaundryApi {
     @POST("auth/google/mobile")
     suspend fun googleMobileLogin(@Body request: GoogleTokenRequest): LoginResponse
 
-    // ==================== USERS ====================
     @GET("users")
     suspend fun getAllUsers(): UsersListResponse
 
@@ -72,7 +71,6 @@ interface LaundryApi {
     @DELETE("users/{id}")
     suspend fun deleteUser(@Path("id") id: Int): MessageResponse
 
-    // ==================== MACHINES ====================
     @GET("machines")
     suspend fun getAllMachines(): MachinesListResponse
 
@@ -88,7 +86,6 @@ interface LaundryApi {
     @DELETE("machines/{id}")
     suspend fun deleteMachine(@Path("id") id: Int): MessageResponse
 
-    // ==================== RESERVATIONS ====================
     @GET("reservations/my")
     suspend fun getMyReservations(): ReservationsListResponse
 
@@ -104,7 +101,6 @@ interface LaundryApi {
     @PUT("reservations/{id}/complete")
     suspend fun completeReservation(@Path("id") id: Int): MessageResponse
 
-    // ==================== NOTIFICATIONS ====================
     @GET("notifications/my")
     suspend fun getMyNotifications(): NotificationsListResponse
 

--- a/app/src/main/java/com/example/mylavanderiapp/features/auth/presentation/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/example/mylavanderiapp/features/auth/presentation/viewmodels/LoginViewModel.kt
@@ -2,6 +2,7 @@ package com.example.mylavanderiapp.features.auth.presentation.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.mylavanderiapp.core.network.WebSocketManager
 import com.example.mylavanderiapp.features.auth.domain.usecases.LoginUseCase
 import com.example.mylavanderiapp.features.auth.presentation.states.LoginFormState
 import com.example.mylavanderiapp.features.auth.presentation.states.LoginUIState
@@ -14,7 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val loginUseCase: LoginUseCase
+    private val loginUseCase: LoginUseCase,
+    private val webSocketManager: WebSocketManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<LoginUIState>(LoginUIState.Idle)
@@ -45,7 +47,10 @@ class LoginViewModel @Inject constructor(
                 password = _formState.value.password
             )
             result.fold(
-                onSuccess = { user -> _uiState.value = LoginUIState.Success(user) },
+                onSuccess = { user ->
+                    webSocketManager.connect()
+                    _uiState.value = LoginUIState.Success(user)
+                },
                 onFailure = { e -> _uiState.value = LoginUIState.Error(e.message ?: "Error al iniciar sesión") }
             )
         }

--- a/app/src/main/java/com/example/mylavanderiapp/features/laundry_reservation/presentation/viewmodels/ReservationViewModel.kt
+++ b/app/src/main/java/com/example/mylavanderiapp/features/laundry_reservation/presentation/viewmodels/ReservationViewModel.kt
@@ -2,6 +2,7 @@ package com.example.mylavanderiapp.features.laundry_reservation.presentation.vie
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.mylavanderiapp.core.network.WebSocketManager
 import com.example.mylavanderiapp.features.laundry_reservation.domain.usecases.CancelReservationUseCase
 import com.example.mylavanderiapp.features.laundry_reservation.domain.usecases.CreateReservationUseCase
 import com.example.mylavanderiapp.features.laundry_reservation.domain.usecases.GetMyReservationsUseCase
@@ -21,7 +22,8 @@ class ReservationViewModel @Inject constructor(
     private val createReservationUseCase: CreateReservationUseCase,
     private val getMyReservationsUseCase: GetMyReservationsUseCase,
     private val cancelReservationUseCase: CancelReservationUseCase,
-    private val getMachinesUseCase: GetMachinesUseCase
+    private val getMachinesUseCase: GetMachinesUseCase,
+    private val webSocketManager: WebSocketManager
 ) : ViewModel() {
 
     private val _createState = MutableStateFlow<ReservationUIState>(ReservationUIState.Idle)
@@ -32,6 +34,19 @@ class ReservationViewModel @Inject constructor(
 
     private val _machinesState = MutableStateFlow<MachinesUIState>(MachinesUIState.Idle)
     val machinesState: StateFlow<MachinesUIState> = _machinesState.asStateFlow()
+
+    init {
+        loadMachines()
+        collectWebSocketEvents()
+    }
+
+    private fun collectWebSocketEvents() {
+        viewModelScope.launch {
+            webSocketManager.notifications.collect {
+                loadMachines()
+            }
+        }
+    }
 
     fun loadMachines() {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/mylavanderiapp/features/machines/presentation/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/example/mylavanderiapp/features/machines/presentation/viewmodels/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.example.mylavanderiapp.features.machines.presentation.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.mylavanderiapp.core.network.WebSocketManager
 import com.example.mylavanderiapp.features.machines.domain.entities.Machine
 import com.example.mylavanderiapp.features.machines.domain.usecases.CreateMachineUseCase
 import com.example.mylavanderiapp.features.machines.domain.usecases.DeleteMachineUseCase
@@ -20,7 +21,8 @@ class HomeViewModel @Inject constructor(
     private val getMachinesUseCase: GetMachinesUseCase,
     private val createMachineUseCase: CreateMachineUseCase,
     private val updateMachineUseCase: UpdateMachineUseCase,
-    private val deleteMachineUseCase: DeleteMachineUseCase
+    private val deleteMachineUseCase: DeleteMachineUseCase,
+    private val webSocketManager: WebSocketManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<MachinesUIState>(MachinesUIState.Idle)
@@ -29,8 +31,18 @@ class HomeViewModel @Inject constructor(
     private val _operationState = MutableStateFlow<MachineOperationState>(MachineOperationState.Idle)
     val operationState = _operationState.asStateFlow()
 
-    init { loadMachines() }
+    init {
+        loadMachines()
+        collectWebSocketEvents()
+    }
 
+    private fun collectWebSocketEvents() {
+        viewModelScope.launch {
+            webSocketManager.notifications.collect {
+                loadMachines()
+            }
+        }
+    }
     fun loadMachines() {
         viewModelScope.launch {
             _uiState.value = MachinesUIState.Loading


### PR DESCRIPTION
- Connect WebSocket on successful login in LoginViewModel
- Remove WebSocket connect/disconnect from NotificationsViewModel lifecycle
- Add collectWebSocketEvents() in HomeViewModel to reload machines on WS event
- Add collectWebSocketEvents() in ReservationViewModel to reload machines on WS event
- Ignore MACHINE_STATUS_CHANGED in NotificationsViewModel to avoid fake notifications
- Add 30s ping interval in WebSocketManager to prevent Cloudflare timeout
- Add automatic reconnection on unexpected disconnect